### PR TITLE
fix: dark mode text visibility on settings screen

### DIFF
--- a/components/ui/Input.tsx
+++ b/components/ui/Input.tsx
@@ -15,6 +15,7 @@ export function Input({
   error,
   helperText,
   containerStyle,
+  style,
   ...props
 }: InputProps) {
   const colorScheme = useColorScheme();
@@ -35,7 +36,8 @@ export function Input({
             backgroundColor: theme.inputBackground,
             borderColor: error ? theme.error : theme.inputBorder,
             color: theme.text,
-          }
+          },
+          style
         ]}
         placeholderTextColor={theme.textSecondary}
         {...props}


### PR DESCRIPTION
Fixes #8

## Description
Fixed the text visibility issue in dark mode on the settings screen for the webhook URL input.

## Changes
- Modified the Input component to properly handle the style prop
- Extracted style prop to ensure it's applied after default styles
- This prevents text color from being overridden in dark mode

## Testing
- Verified that text is now visible in dark mode
- Ensured existing functionality remains intact

Generated with [Claude Code](https://claude.ai/code)